### PR TITLE
fix: changed deprecated docker links to network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 *.iml
 /uvms-pom/target/

--- a/uvms-pom/pom.xml
+++ b/uvms-pom/pom.xml
@@ -198,6 +198,7 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
                             </execution>
                         </executions>
                         <configuration>
+                            <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
                             <images>
                                 <image>
                                     <alias>postgres</alias>
@@ -205,6 +206,9 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
                                     <run>
                                         <net>bridge</net>
                                         <namingStrategy>none</namingStrategy>
+                                        <network>
+                                            <name>uvms-net</name>
+                                        </network>
                                         <ports>
                                             <port>15432:5432</port>
                                         </ports>
@@ -221,9 +225,9 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
                                     <run>
                                         <net>bridge</net>
                                         <namingStrategy>none</namingStrategy>
-                                        <links>
-                                            <link>postgres:postgres</link>
-                                        </links>
+                                        <network>
+                                            <name>uvms-net</name>
+                                        </network>
                                         <ports>
                                             <port>9990:9990</port>
                                             <port>28787:8787</port>


### PR DESCRIPTION
Podman doesn't have support for links and links are considered legacy/deprecated in favor of network.