### PR TITLE
test: removes powermock as a dep

### DIFF
--- a/uvms-pom-arquillian-deps/pom.xml
+++ b/uvms-pom-arquillian-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.maven</groupId>
         <artifactId>focus-pom</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <relativePath/>
     </parent>
 

--- a/uvms-pom-gis-deps/pom.xml
+++ b/uvms-pom-gis-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.maven</groupId>
         <artifactId>focus-pom</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <relativePath/>
     </parent>
 

--- a/uvms-pom-java11-deps/pom.xml
+++ b/uvms-pom-java11-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.maven</groupId>
         <artifactId>focus-pom</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <relativePath/>
     </parent>
 

--- a/uvms-pom-monitoring-deps/pom.xml
+++ b/uvms-pom-monitoring-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.maven</groupId>
         <artifactId>focus-pom</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <relativePath/>
     </parent>
 

--- a/uvms-pom-test-deps/pom.xml
+++ b/uvms-pom-test-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fish.focus.maven</groupId>
         <artifactId>focus-pom</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <relativePath/>
     </parent>
 
@@ -19,7 +19,6 @@
         <uvms-pom.test.deps.junit.version>4.13.2</uvms-pom.test.deps.junit.version>
         <uvms-pom.test.deps.mockito.version>5.14.2</uvms-pom.test.deps.mockito.version>
         <uvms-pom.test.deps.easycoverage>2.3.1</uvms-pom.test.deps.easycoverage>
-        <uvms-pom.test.deps.powermock.version>2.0.9</uvms-pom.test.deps.powermock.version>
         <uvms-pom.test.deps.awaitility.version>4.2.2</uvms-pom.test.deps.awaitility.version>
         <uvms-pom.test.deps.hamcrest.version>3.0</uvms-pom.test.deps.hamcrest.version>
     </properties>
@@ -45,20 +44,10 @@
             <artifactId>mockito-core</artifactId>
             <version>${uvms-pom.test.deps.mockito.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${uvms-pom.test.deps.powermock.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${uvms-pom.test.deps.powermock.version}</version>
-        </dependency>
         <dependency>                <!--  This one is here to resolve a dependency conflict involving junit, powermock and hibernate    -->
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.10.2</version>
+            <version>1.15.7</version>
         </dependency>
         <dependency>
             <groupId>com.tocea.easycoverage</groupId>

--- a/uvms-pom/pom.xml
+++ b/uvms-pom/pom.xml
@@ -16,7 +16,7 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
     <parent>
         <groupId>fish.focus.maven</groupId>
         <artifactId>focus-pom</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Mockito supports static mocking and PowerMock does not work under newer versions of Mockito.
See https://github.com/powermock/powermock/issues/1112