### PR TITLE
fix: adds Mockito as an agent

### DIFF
--- a/uvms-pom/pom.xml
+++ b/uvms-pom/pom.xml
@@ -66,6 +66,7 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
         <!-- ======= -->
         <!-- Plugins -->
         <!-- ======= -->
+        <argLine/>
 
         <!-- ======================= -->
         <!-- Default docker settings -->
@@ -145,6 +146,24 @@ License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses />. 
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Java 21 and onwards restricts the ability of libraries to attach a Java agent to their own JVM.

See
https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3 for more information.